### PR TITLE
fix(grep): remove duplicate options

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -24,8 +24,8 @@ else
     if [[ -n "$GREP_OPTIONS" ]]; then
         # export grep, egrep and fgrep settings
         alias grep="grep $GREP_OPTIONS"
-        alias egrep="grep -E $GREP_OPTIONS"
-        alias fgrep="grep -F $GREP_OPTIONS"
+        alias egrep="grep -E"
+        alias fgrep="grep -F"
 
         # write to cache file if cache directory is writable
         if [[ -w "$ZSH_CACHE_DIR" ]]; then


### PR DESCRIPTION
Grep options are added twice when using `egrep` and `fgrep` aliases.

The options are added one time on the `grep` alias, and a second time on the `egrep` and `fgrep` aliases definitions.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
